### PR TITLE
RFC: Drop the user and group identifiers from the docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,50 +1,19 @@
 # SPDX-License-Identifier: GPL-2.0
-
 ARG BASE_IMAGE
-FROM ${BASE_IMAGE} as base
+FROM $BASE_IMAGE
 
+ARG RUN_CMD
 ARG SNPTEST_VER
-ARG SNPTEST_DIR
-
-# user data provided by the host system via the make file
-# without these, the container will fail-safe and be unable to write output
-ARG USERNAME
-ARG USERID
-ARG USERGNAME
-ARG USERGID
-
-# Put the ARGs into the ENV, so the runtime inherits them
-ENV SNPTEST_VER=${SNPTEST_VER}
-ENV SNPTEST_DIR=${SNPTEST_DIR}
-
-# Put the user name and ID into the ENV, so the runtime inherits them
-ENV USERNAME=${USERNAME:-nouser} \
-	USERID=${USERID:-65533} \
-	USERGID=${USERGID:-nogroup}
-
-# match the building user. This will allow output only where the building
-# user has write permissions
-RUN groupadd -g $USERGID $USERGNAME && \
-	useradd -m -u $USERID -g $USERGID $USERNAME && \
-	adduser $USERNAME $USERGNAME
 
 # Install OS updates, security fixes and utils, generic app dependencies
-# htslib is libhts3 in Ubuntu see https://github.com/samtools/htslib/
 RUN apt -y update -qq && apt -y upgrade && \
 	DEBIAN_FRONTEND=noninteractive apt -y install \
-		ca-certificates \
-		dirmngr \
-		ghostscript gnuplot \
+		ca-certificates curl libcurl3-gnutls \
 		less libfile-pushd-perl libhts3 \
-		software-properties-common \
 		strace wget xz-utils zlib1g
 
-# This creates the actual container we will run
-FROM base AS release
-
-# these args may need to be abstracted for a more generic deployment
-
-WORKDIR /runtime
+# analytics package target - we want a new layer here, since different
+# dependencies will have to be installed, sharing the common base above
 
 ARG SNPTEST_URL="www.well.ox.ac.uk/~gav/resources/"
 ARG SNPTEST="snptest_v${SNPTEST_VER}"
@@ -52,13 +21,15 @@ ARG SNPTEST_ARCH="x86_64_dynamic"
 ARG SNPTEST_BUILD="2003"
 ARG SNPTEST_DIST=${SNPTEST}_CentOS_Linux7.8
 ARG SNPTEST_TAR=${SNPTEST_DIST}-${SNPTEST_ARCH}.tgz
+ARG SNPTEST_DIR="/usr/local/bin"
 
-RUN wget https://${SNPTEST_URL}/$SNPTEST_TAR && mkdir -p ${SNPTEST_DIR} && \
+RUN wget https://${SNPTEST_URL}/$SNPTEST_TAR && \
 	tar xvf $SNPTEST_TAR --strip-components=1 -C ${SNPTEST_DIR} && \
-	rm $SNPTEST_TAR && \
-	ln -s ${SNPTEST_DIR}/${SNPTEST} /usr/local/bin/snptest
+	ln -s ${SNPTEST_DIR}/${SNPTEST} "${SNPTEST_DIR}/${RUN_CMD}" && \
+	rm $SNPTEST_TAR
 
-# we map the user owning the image so permissions for input/output will work
-USER $USERNAME
-
-ENTRYPOINT [ "snptest" ]
+ENV PATH=${PATH}:${SNPTEST_DIR}
+# Create an entrypoint for the binary
+RUN echo "#!/bin/bash\n$RUN_CMD \$@" > /entrypoint.sh && \
+	chmod +x /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/Makefile
+++ b/Makefile
@@ -1,47 +1,73 @@
 # SPDX-License-Identifier: GPL-2.0
 
 ORG_NAME := hihg-um
-PROJECT_NAME ?= snptest
-SNPTEST_VER ?= 2.5.6
 OS_BASE ?= ubuntu
 OS_VER ?= 22.04
 
-USER ?= `whoami`
-USERID := `id -u`
-USERGNAME ?= "adgc"
-USERGID ?= 5000
-
 IMAGE_REPOSITORY :=
-IMAGE := $(ORG_NAME)/$(USER)/$(PROJECT_NAME):latest
+GIT_TAG := $(shell git tag)
+GIT_REV := $(shell git describe --always --dirty)
+DOCKER_TAG ?= $(GIT_TAG)-$(GIT_REV)
 
 # Use this for debugging builds. Turn off for a more slick build log
 DOCKER_BUILD_ARGS := --progress=plain
 
-SNPTEST_DIR := /opt/$(PROJECT_NAME)
+TOOLS := snptest
+DOCKER_IMAGES := $(TOOLS:=\:$(DOCKER_TAG))
+SVF_IMAGES := $(TOOLS:=\:$(DOCKER_TAG).svf)
 
-.PHONY: all build clean test tests
+# SNPTEST-specific
+SNPTEST_VER := 2.5.6
 
-all: docker test
+.PHONY: clean docker test test_apptainer test_docker $(DOCKER_IMAGES)
 
-test: docker
-	@docker run -t $(IMAGE) snptest -help > /dev/null
+help:
+	@echo "Targets: all clean test"
+	@echo "         docker test_docker release_docker"
+	@echo "         apptainer test_apptainer"
+	@echo "Docker containers:\n$(DOCKER_IMAGES)"
+	@echo
+	@echo "Apptainer images:\n$(SVF_IMAGES)"
 
-tests: test
+all: clean docker test_docker apptainer test_apptainer
 
 clean:
-	@docker rmi $(IMAGE)
+	rm -f $(SVF_IMAGES)
+	for f in $(TOOLS); do \
+		docker rmi -f $(ORG_NAME)/$$f 2>/dev/null; \
+	done
 
-docker:
-	@docker build -t $(IMAGE) \
-		--build-arg BASE_IMAGE=$(OS_BASE):$(OS_VER) \
-		--build-arg SNPTEST_VER=$(SNPTEST_VER) \
-		--build-arg SNPTEST_DIR="$(SNPTEST_DIR)" \
-		--build-arg USERNAME=$(USER) \
-		--build-arg USERID=$(USERID) \
-		--build-arg USERGNAME=$(USERGNAME) \
-		--build-arg USERGID=$(USERGID) \
+test: test_docker test_apptainer
+
+$(TOOLS):
+	@echo "Building Docker container $@"
+	docker build -t $(ORG_NAME)/$@:$(DOCKER_TAG) \
 		$(DOCKER_BUILD_ARGS) \
-	  .
+		--build-arg BASE_IMAGE=$(OS_BASE):$(OS_VER) \
+		--build-arg RUN_CMD=$@ \
+		--build-arg SNPTEST_VER=$(SNPTEST_VER) \
+		.
 
-release:
-	docker push $(IMAGE_REPOSITORY)/$(IMAGE)
+docker: $(TOOLS)
+
+test_docker: $(DOCKER_IMAGES)
+	for f in $^; do \
+		echo "Testing Docker container: $(ORG_NAME)/$$f"; \
+		docker run -t --user $(id -u):$(id -g) -v /mnt:/mnt \
+			$(ORG_NAME)/$$f -help; \
+	done
+
+release_docker: $(DOCKER_IMAGES)
+	docker push $(IMAGE_REPOSITORY)/$(ORG_NAME)/$@
+
+$(SVF_IMAGES):
+	@echo "Building Apptainer $@"
+	apptainer build $@ docker-daemon:$(ORG_NAME)/$(patsubst %.svf,%,$@)
+
+apptainer: $(SVF_IMAGES)
+
+test_apptainer: $(SVF_IMAGES)
+	for f in $^; do \
+		echo "Testing Apptainer image: $$f"; \
+		apptainer run $$f -help; \
+	done


### PR DESCRIPTION
 - this eliminates per-user images for otherwise identical containers
 - the docker run --user parameter will substitute for this
 - security is not impacted because trivial hack-arounds remain, that are generally addressed by Apptainer